### PR TITLE
Move Supabase behind API routes (closes #2)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,6 +31,6 @@ jobs:
 
       - name: Check build
         env:
-          NEXT_PUBLIC_SUPABASE_URL: https://placeholder.supabase.co
-          NEXT_PUBLIC_SUPABASE_ANON_KEY: placeholder-key
+          SUPABASE_URL: https://placeholder.supabase.co
+          SUPABASE_SERVICE_ROLE_KEY: placeholder-key
         run: npm run build

--- a/src/app/api/download/[id]/route.ts
+++ b/src/app/api/download/[id]/route.ts
@@ -1,0 +1,51 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { supabaseAdmin } from '@/lib/supabase-server';
+
+export async function GET(
+  _request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const { id } = await params;
+
+  // Check file exists and isn't expired
+  const { data: fileMeta, error: metaError } = await supabaseAdmin
+    .from('files')
+    .select('id, expires_at')
+    .eq('id', id)
+    .single();
+
+  if (metaError || !fileMeta) {
+    return NextResponse.json(
+      { error: 'File not found' },
+      { status: 404 }
+    );
+  }
+
+  if (new Date(fileMeta.expires_at) < new Date()) {
+    return NextResponse.json(
+      { error: 'File expired' },
+      { status: 410 }
+    );
+  }
+
+  // Download ciphertext from storage
+  const { data: blob, error: downloadError } = await supabaseAdmin.storage
+    .from('files')
+    .download(id);
+
+  if (downloadError || !blob) {
+    return NextResponse.json(
+      { error: 'Download failed' },
+      { status: 500 }
+    );
+  }
+
+  const buffer = Buffer.from(await blob.arrayBuffer());
+
+  return new NextResponse(buffer, {
+    headers: {
+      'Content-Type': 'application/octet-stream',
+      'Content-Length': buffer.length.toString(),
+    },
+  });
+}

--- a/src/app/api/file/[id]/route.ts
+++ b/src/app/api/file/[id]/route.ts
@@ -1,0 +1,31 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { supabaseAdmin } from '@/lib/supabase-server';
+
+export async function GET(
+  _request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const { id } = await params;
+
+  const { data, error } = await supabaseAdmin
+    .from('files')
+    .select('id, file_name, file_size, expires_at, created_at')
+    .eq('id', id)
+    .single();
+
+  if (error || !data) {
+    return NextResponse.json(
+      { error: 'File not found' },
+      { status: 404 }
+    );
+  }
+
+  if (new Date(data.expires_at) < new Date()) {
+    return NextResponse.json(
+      { error: 'File expired' },
+      { status: 410 }
+    );
+  }
+
+  return NextResponse.json(data);
+}

--- a/src/app/api/upload/route.ts
+++ b/src/app/api/upload/route.ts
@@ -1,0 +1,91 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { supabaseAdmin } from '@/lib/supabase-server';
+
+const MAX_FILE_SIZE = 50 * 1024 * 1024; // 50MB
+const VALID_EXPIRY_HOURS = [1, 6, 24];
+
+function generateId(length = 10): string {
+  const chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
+  let result = '';
+  const values = crypto.getRandomValues(new Uint8Array(length));
+  for (const val of values) {
+    result += chars[val % chars.length];
+  }
+  return result;
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    const formData = await request.formData();
+    const file = formData.get('file') as File | null;
+    const fileName = formData.get('file_name') as string | null;
+    const fileSizeStr = formData.get('file_size') as string | null;
+    const expiryHoursStr = formData.get('expiry_hours') as string | null;
+
+    if (!file || !fileName || !fileSizeStr || !expiryHoursStr) {
+      return NextResponse.json(
+        { error: 'Missing required fields: file, file_name, file_size, expiry_hours' },
+        { status: 400 }
+      );
+    }
+
+    const fileSize = parseInt(fileSizeStr, 10);
+    const expiryHours = parseInt(expiryHoursStr, 10);
+
+    if (fileSize > MAX_FILE_SIZE) {
+      return NextResponse.json(
+        { error: `File too large. Maximum size is ${MAX_FILE_SIZE / (1024 * 1024)}MB` },
+        { status: 413 }
+      );
+    }
+
+    if (!VALID_EXPIRY_HOURS.includes(expiryHours)) {
+      return NextResponse.json(
+        { error: `Invalid expiry. Must be one of: ${VALID_EXPIRY_HOURS.join(', ')} hours` },
+        { status: 400 }
+      );
+    }
+
+    const fileId = generateId();
+    const expiresAt = new Date(Date.now() + expiryHours * 60 * 60 * 1000).toISOString();
+
+    const buffer = Buffer.from(await file.arrayBuffer());
+
+    const { error: uploadError } = await supabaseAdmin.storage
+      .from('files')
+      .upload(fileId, buffer, {
+        contentType: 'application/octet-stream',
+        upsert: false,
+      });
+
+    if (uploadError) {
+      return NextResponse.json(
+        { error: 'Upload failed' },
+        { status: 500 }
+      );
+    }
+
+    const { error: dbError } = await supabaseAdmin.from('files').insert({
+      id: fileId,
+      file_name: fileName,
+      file_size: fileSize,
+      expires_at: expiresAt,
+    });
+
+    if (dbError) {
+      // Clean up storage if DB insert fails
+      await supabaseAdmin.storage.from('files').remove([fileId]);
+      return NextResponse.json(
+        { error: 'Failed to save file metadata' },
+        { status: 500 }
+      );
+    }
+
+    return NextResponse.json({ id: fileId });
+  } catch {
+    return NextResponse.json(
+      { error: 'Internal server error' },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/f/[id]/page.tsx
+++ b/src/app/f/[id]/page.tsx
@@ -12,7 +12,6 @@ import {
 } from 'lucide-react';
 import { AboutModal } from '@/components/AboutModal';
 import { importKey, decryptFile } from '@/lib/encryption';
-import { supabase } from '@/lib/supabase';
 import { formatFileSize } from '@/lib/utils';
 
 type FileMetadata = {
@@ -54,22 +53,19 @@ export default function DownloadPage({
     }
 
     async function loadFile() {
-      const { data, error } = await supabase
-        .from('files')
-        .select('*')
-        .eq('id', id)
-        .single();
+      const res = await fetch(`/api/file/${id}`);
 
-      if (error || !data) {
-        setState('not-found');
-        return;
-      }
-
-      if (new Date(data.expires_at) < new Date()) {
+      if (res.status === 410) {
         setState('expired');
         return;
       }
 
+      if (!res.ok) {
+        setState('not-found');
+        return;
+      }
+
+      const data = await res.json();
       setFileData(data);
       setState('ready');
     }
@@ -117,11 +113,11 @@ export default function DownloadPage({
       const keyString = window.location.hash.slice(1);
 
       setState('downloading');
-      const { data: blob, error: downloadError } = await supabase.storage
-        .from('files')
-        .download(fileData.id);
+      const downloadRes = await fetch(`/api/download/${fileData.id}`);
 
-      if (downloadError || !blob) throw new Error('DOWNLOAD_FAILED');
+      if (!downloadRes.ok) throw new Error('DOWNLOAD_FAILED');
+
+      const blob = await downloadRes.blob();
 
       setState('decrypting');
       const key = await importKey(keyString);

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -4,8 +4,7 @@ import { useState, useCallback, useRef } from 'react';
 import { Copy, Check, File as FileIcon, Loader2, X } from 'lucide-react';
 import { AboutModal } from '@/components/AboutModal';
 import { generateKey, exportKey, encryptFile } from '@/lib/encryption';
-import { supabase } from '@/lib/supabase';
-import { generateId, formatFileSize } from '@/lib/utils';
+import { formatFileSize } from '@/lib/utils';
 
 type ExpiryOption = { label: string; tag: string; hours: number };
 
@@ -59,27 +58,23 @@ export default function Home() {
       const encryptedBlob = await encryptFile(file, key);
 
       setState('uploading');
-      const fileId = generateId();
-      const expiresAt = new Date(
-        Date.now() + expiry.hours * 60 * 60 * 1000
-      ).toISOString();
+      const formData = new FormData();
+      formData.append('file', encryptedBlob);
+      formData.append('file_name', file.name);
+      formData.append('file_size', file.size.toString());
+      formData.append('expiry_hours', expiry.hours.toString());
 
-      const { error: uploadError } = await supabase.storage
-        .from('files')
-        .upload(fileId, encryptedBlob, {
-          contentType: 'application/octet-stream',
-          upsert: false,
-        });
-      if (uploadError) throw uploadError;
-
-      const { error: dbError } = await supabase.from('files').insert({
-        id: fileId,
-        file_name: file.name,
-        file_size: file.size,
-        expires_at: expiresAt,
+      const res = await fetch('/api/upload', {
+        method: 'POST',
+        body: formData,
       });
-      if (dbError) throw dbError;
 
+      if (!res.ok) {
+        const data = await res.json();
+        throw new Error(data.error || 'Upload failed');
+      }
+
+      const { id: fileId } = await res.json();
       setShareUrl(`${window.location.origin}/f/${fileId}#${keyString}`);
       setState('done');
     } catch (err) {

--- a/src/lib/supabase-server.ts
+++ b/src/lib/supabase-server.ts
@@ -1,0 +1,6 @@
+import { createClient } from '@supabase/supabase-js';
+
+const supabaseUrl = process.env.SUPABASE_URL || '';
+const supabaseServiceKey = process.env.SUPABASE_SERVICE_ROLE_KEY || '';
+
+export const supabaseAdmin = createClient(supabaseUrl, supabaseServiceKey);

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -1,6 +1,0 @@
-import { createClient } from '@supabase/supabase-js';
-
-const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL || '';
-const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY || '';
-
-export const supabase = createClient(supabaseUrl, supabaseAnonKey);

--- a/supabase-setup.sql
+++ b/supabase-setup.sql
@@ -1,5 +1,5 @@
 -- ============================================
--- Beam - Supabase Setup
+-- PHANTM - Supabase Setup
 -- Run this in your Supabase SQL Editor
 -- ============================================
 


### PR DESCRIPTION
## Summary
- Introduces 3 Next.js API routes (`/api/upload`, `/api/file/[id]`, `/api/download/[id]`) as the sole interface to Supabase
- Supabase credentials moved server-side only (`SUPABASE_URL` + `SUPABASE_SERVICE_ROLE_KEY`) — no more `NEXT_PUBLIC_*` keys
- Client JS bundle has zero Supabase references — verified by scanning all chunks
- Client-side `src/lib/supabase.ts` deleted; replaced by server-only `src/lib/supabase-server.ts`
- Upload page uses `fetch('/api/upload')` with multipart FormData
- Download page uses `fetch('/api/file/...')` and `fetch('/api/download/...')`
- Server-side expiry validation on both metadata and download endpoints (404/410)
- Encryption/decryption remains fully client-side — zero-knowledge preserved

## Why
The CLI tool (`phntm.sh`) needs a proper API to talk to. Without this, the CLI would need embedded Supabase credentials. Now both web and CLI hit the same HTTP API.

## Test plan
- [x] Upload file via web UI — encrypts client-side, uploads via `/api/upload`
- [x] Download page loads file metadata via `/api/file/[id]`
- [x] Download + decrypt via `/api/download/[id]` — file content verified identical
- [x] No Supabase references in any client JS bundle (0 matches across all chunks)
- [x] TypeScript passes (`tsc --noEmit`)
- [x] Production build passes
- [x] CI env vars updated

Closes #2

🤖 Generated with [Claude Code](https://claude.com/claude-code)