### PR TITLE
Pass raw.buffer instead of raw

### DIFF
--- a/src/lib/encryption.ts
+++ b/src/lib/encryption.ts
@@ -19,7 +19,7 @@ export async function importKey(encoded: string): Promise<CryptoKey> {
   const raw = base64urlToBuffer(encoded);
   return crypto.subtle.importKey(
     'raw',
-    raw.buffer as ArrayBuffer,
+    new Uint8Array(raw) as BufferSource,
     { name: ALGORITHM, length: KEY_LENGTH },
     false,
     ['decrypt']


### PR DESCRIPTION
## What

Build was failing on Vercel 

## Why

The issue arises because Vercel employs a newer version of TypeScript (5.6+) where Uint8Array has become generic. Specifically, Uint8Array<ArrayBufferLike> doesn’t satisfy the BufferSource requirement, which expects an ArrayBuffer, not an ArrayBufferLike. This discrepancy occurs because your local TypeScript version is older and lacks this stricter typing.

To resolve this, you should pass raw.buffer as an ArrayBuffer instead of passing raw directly. The .buffer property of a Uint8Array holds the underlying ArrayBuffer, and casting it to an ArrayBuffer satisfies the stricter type check. 

## How to test

Let it build

## Checklist

- [ ] `npx tsc --noEmit` passes
- [ ] `npm run lint` passes
- [ ] `npm test` passes
- [ ] `npm run build` succeeds
