### PR TITLE
Fix CLI 403 on upload by allowing X-Phntm-Client header

### DIFF
--- a/src/app/api/upload/confirm/route.ts
+++ b/src/app/api/upload/confirm/route.ts
@@ -7,7 +7,10 @@ const VALID_EXPIRY_HOURS = [1, 6, 24];
 export async function POST(request: NextRequest) {
   const origin = request.headers.get('origin');
   const host = request.headers.get('host');
-  if (!origin || !host || !origin.endsWith(host.replace(/:\d+$/, ''))) {
+  const clientType = request.headers.get('x-phntm-client');
+  const isBrowser = origin && host && origin.endsWith(host.replace(/:\d+$/, ''));
+  const isCLI = clientType === 'cli';
+  if (!isBrowser && !isCLI) {
     return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
   }
 

--- a/src/app/api/upload/route.ts
+++ b/src/app/api/upload/route.ts
@@ -23,7 +23,10 @@ function generateId(length = 10): string {
 export async function POST(request: NextRequest) {
   const origin = request.headers.get('origin');
   const host = request.headers.get('host');
-  if (!origin || !host || !origin.endsWith(host.replace(/:\d+$/, ''))) {
+  const clientType = request.headers.get('x-phntm-client');
+  const isBrowser = origin && host && origin.endsWith(host.replace(/:\d+$/, ''));
+  const isCLI = clientType === 'cli';
+  if (!isBrowser && !isCLI) {
     return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
   }
 


### PR DESCRIPTION
## Summary
- The CSRF origin validation from the security audit blocks CLI uploads since Go's `http.Client` doesn't send `Origin` headers
- Upload routes now accept requests with `X-Phntm-Client: cli` header as an alternative to browser origin matching
- Affects `/api/upload` and `/api/upload/confirm`

## Test plan
- [ ] Verify web uploads still work (browser origin check unchanged)
- [ ] Verify `phntm send` no longer gets 403 after CLI is rebuilt with the matching header
- [ ] Verify requests without origin AND without `X-Phntm-Client: cli` still get 403