### PR TITLE
Strip URL fragment from Vercel Analytics to prevent key leakage

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,7 +2,7 @@ import type { Metadata } from "next";
 import { Geist_Mono } from "next/font/google";
 import { EasterEggs } from "@/components/EasterEggs";
 import "./globals.css";
-import { Analytics } from "@vercel/analytics/next"
+import { SafeAnalytics } from "@/components/SafeAnalytics";
 const geistMono = Geist_Mono({
   variable: "--font-geist-mono",
   subsets: ["latin"],
@@ -29,13 +29,7 @@ export default function RootLayout({
       <body className={`${geistMono.variable} antialiased`}>
         <EasterEggs />
         {children}
-        <Analytics
-          beforeSend={(event) => {
-            const url = new URL(event.url);
-            url.hash = '';
-            return { ...event, url: url.toString() };
-          }}
-        />
+        <SafeAnalytics />
       </body>
     </html>
   );

--- a/src/components/SafeAnalytics.tsx
+++ b/src/components/SafeAnalytics.tsx
@@ -1,0 +1,15 @@
+'use client';
+
+import { Analytics } from '@vercel/analytics/react';
+
+export function SafeAnalytics() {
+  return (
+    <Analytics
+      beforeSend={(event) => {
+        const url = new URL(event.url);
+        url.hash = '';
+        return { ...event, url: url.toString() };
+      }}
+    />
+  );
+}


### PR DESCRIPTION
## Summary
- Vercel Analytics uses `location.href` client-side which includes the `#hash` fragment
- Since decryption keys live in the URL fragment (`/f/{id}#{key}`), this was sending keys to Vercel's analytics endpoint
- Added `beforeSend` callback to strip the hash before events are transmitted

## Context
Flagged during a Reddit discussion — Vercel Analytics reads the full URL client-side and POSTs it to their servers. The RFC is correct that browsers don't send fragments in HTTP requests, but client-side JS analytics scripts bypass that by reading `location.href` directly.

## Test plan
- [ ] Verify Vercel Analytics still tracks pageviews (without the hash)
- [ ] Confirm no `#` fragments appear in Vercel Analytics dashboard