### PR TITLE
Feature: Secure Notes - Terminal-Style Text Input

### DIFF
--- a/src/app/f/[id]/page.tsx
+++ b/src/app/f/[id]/page.tsx
@@ -18,6 +18,7 @@ import {
   FileAudio,
   Archive,
   Code,
+  Copy,
 } from 'lucide-react';
 import { AboutModal } from '@/components/AboutModal';
 import { importKey, decryptFile } from '@/lib/streaming-encryption';
@@ -47,13 +48,20 @@ type PageState =
 function FileCard({
   state,
   fileData,
+  noteText,
+  copied,
   handleDownload,
+  handleCopyNote,
 }: {
   state: PageState;
   fileData: FileMetadata;
+  noteText?: string | null;
+  copied?: boolean;
   handleDownload: () => void;
+  handleCopyNote?: () => void;
 }) {
   const fileInfo = getFileInfo(fileData.file_name);
+  const isNote = fileData.file_name.toLowerCase().endsWith('.txt');
   const IconComponent = fileInfo.icon === 'file-text' ? FileText :
     fileInfo.icon === 'file-spreadsheet' ? FileSpreadsheet :
     fileInfo.icon === 'file-image' ? FileImage :
@@ -69,7 +77,7 @@ function FileCard({
       {/* Trust signal — file info prominently displayed */}
       <div className="text-center space-y-2">
         <p className="text-[11px] text-muted tracking-[0.15em]">
-          {fileInfo.description.toUpperCase()} • {formatFileSize(fileData.file_size)}
+          {isNote ? 'SECURE NOTE' : fileInfo.description.toUpperCase()} • {formatFileSize(fileData.file_size)}
         </p>
       </div>
 
@@ -90,13 +98,23 @@ function FileCard({
         </div>
 
         {/* Action */}
-        {state === 'ready' && (
+        {state === 'ready' && !isNote && (
           <button
             onClick={handleDownload}
             className="ghost-btn-accent w-full py-3 text-[11px] tracking-[0.2em] border flex items-center justify-center gap-2"
           >
             <Download className="w-4 h-4" />
             [ DOWNLOAD ]
+          </button>
+        )}
+
+        {state === 'ready' && isNote && (
+          <button
+            onClick={handleDownload}
+            className="ghost-btn-accent w-full py-3 text-[11px] tracking-[0.2em] border flex items-center justify-center gap-2"
+          >
+            <FileText className="w-4 h-4" />
+            [ VIEW NOTE ]
           </button>
         )}
 
@@ -136,7 +154,7 @@ function FileCard({
           </div>
         )}
 
-        {state === 'complete' && (
+        {state === 'complete' && !isNote && (
           <div className="flex flex-col items-center gap-1.5 py-3">
             <div className="flex items-center gap-3">
               <Check className="w-4 h-4 text-accent" />
@@ -151,6 +169,64 @@ function FileCard({
               className="text-[10px] text-muted tracking-[0.1em]"
               scrambleDuration={1000}
             />
+          </div>
+        )}
+
+        {state === 'complete' && isNote && noteText && (
+          <div className="space-y-3">
+            <div className="flex items-center gap-3">
+              <Check className="w-4 h-4 text-accent" />
+              <ScrambleText
+                text="DECRYPTION_COMPLETE"
+                className="text-[11px] text-accent tracking-[0.15em]"
+                scrambleDuration={800}
+              />
+            </div>
+            {/* Terminal-style note display */}
+            <div className="border border-border bg-[#0d1117] rounded-sm overflow-hidden">
+              <div className="flex items-center justify-between px-3 py-2 border-b border-border">
+                <span className="text-[10px] text-muted tracking-[0.1em]">SECURE NOTE</span>
+                <span className="text-[10px] text-muted">{noteText.length} chars</span>
+              </div>
+              <pre className="p-4 text-[11px] text-fg font-mono whitespace-pre-wrap break-words max-h-64 overflow-auto">
+                {noteText}
+              </pre>
+            </div>
+            <div className="flex gap-2">
+              <button
+                onClick={handleCopyNote}
+                className="ghost-btn-accent flex-1 py-2 text-[11px] tracking-[0.15em] border flex items-center justify-center gap-2"
+              >
+                {copied ? (
+                  <>
+                    <Check className="w-3 h-3" />
+                    COPIED
+                  </>
+                ) : (
+                  <>
+                    <Copy className="w-3 h-3" />
+                    COPY
+                  </>
+                )}
+              </button>
+              <button
+                onClick={() => {
+                  const blob = new Blob([noteText], { type: 'text/plain' });
+                  const url = URL.createObjectURL(blob);
+                  const a = document.createElement('a');
+                  a.href = url;
+                  a.download = fileData.file_name;
+                  document.body.appendChild(a);
+                  a.click();
+                  document.body.removeChild(a);
+                  URL.revokeObjectURL(url);
+                }}
+                className="ghost-btn flex-1 py-2 text-[11px] tracking-[0.15em] border flex items-center justify-center gap-2"
+              >
+                <Download className="w-3 h-3" />
+                DOWNLOAD
+              </button>
+            </div>
           </div>
         )}
       </div>
@@ -173,6 +249,8 @@ export default function DownloadPage({
   const { id } = use(params);
   const [state, setState] = useState<PageState>('loading');
   const [fileData, setFileData] = useState<FileMetadata | null>(null);
+  const [noteText, setNoteText] = useState<string | null>(null);
+  const [copied, setCopied] = useState(false);
   const [error, setError] = useState('');
   const [countdown, setCountdown] = useState('--:--:--');
   const [progress, setProgress] = useState(100);
@@ -287,23 +365,40 @@ export default function DownloadPage({
       const encryptedBuffer = await blob.arrayBuffer();
       const decryptedBuffer = await decryptFile(encryptedBuffer, key);
 
-      const decryptedBlob = new Blob([decryptedBuffer]);
-      const url = URL.createObjectURL(decryptedBlob);
-      const a = document.createElement('a');
-      a.href = url;
-      a.download = fileData.file_name;
-      document.body.appendChild(a);
-      a.click();
-      document.body.removeChild(a);
-      URL.revokeObjectURL(url);
-
-      setState('complete');
+      // Check if it's a note (text file)
+      const isNote = fileData.file_name.toLowerCase().endsWith('.txt');
+      
+      if (isNote) {
+        // Display note inline
+        const text = new TextDecoder().decode(decryptedBuffer);
+        setNoteText(text);
+        setState('complete');
+      } else {
+        // Download file
+        const decryptedBlob = new Blob([decryptedBuffer]);
+        const url = URL.createObjectURL(decryptedBlob);
+        const a = document.createElement('a');
+        a.href = url;
+        a.download = fileData.file_name;
+        document.body.appendChild(a);
+        a.click();
+        document.body.removeChild(a);
+        URL.revokeObjectURL(url);
+        setState('complete');
+      }
     } catch (err) {
       setError(
         err instanceof Error ? err.message : 'DECRYPTION_FAILED: INVALID KEY'
       );
       setState('error');
     }
+  };
+
+  const handleCopyNote = async () => {
+    if (!noteText) return;
+    await navigator.clipboard.writeText(noteText);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
   };
 
   return (
@@ -426,7 +521,10 @@ export default function DownloadPage({
             <FileCard
               state={state}
               fileData={fileData}
+              noteText={noteText}
+              copied={copied}
               handleDownload={handleDownload}
+              handleCopyNote={handleCopyNote}
             />
           </>
         )}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -9,6 +9,7 @@ import { generateKey, exportKey, encryptFileStream } from '@/lib/streaming-encry
 import { formatFileSize } from '@/lib/utils';
 
 type ExpiryOption = { label: string; tag: string; hours: number };
+type UploadMode = 'file' | 'text';
 
 const EXPIRY_OPTIONS: ExpiryOption[] = [
   { label: '1 hour', tag: '01H', hours: 1 },
@@ -17,18 +18,22 @@ const EXPIRY_OPTIONS: ExpiryOption[] = [
 ];
 
 const MAX_FILE_SIZE = 512 * 1024 * 1024;
+const MAX_TEXT_SIZE = 10 * 1024; // 10KB
 
 type AppState = 'idle' | 'encrypting' | 'uploading' | 'done' | 'error';
 
 export default function Home() {
   const [state, setState] = useState<AppState>('idle');
+  const [mode, setMode] = useState<UploadMode>('file');
   const [file, setFile] = useState<File | null>(null);
+  const [text, setText] = useState('');
   const [expiry, setExpiry] = useState<ExpiryOption>(EXPIRY_OPTIONS[2]);
   const [shareUrl, setShareUrl] = useState('');
   const [copied, setCopied] = useState(false);
   const [error, setError] = useState('');
   const [dragOver, setDragOver] = useState(false);
   const fileInputRef = useRef<HTMLInputElement>(null);
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
 
   const handleFileSelect = useCallback((selectedFile: File) => {
     if (selectedFile.size > MAX_FILE_SIZE) {
@@ -52,22 +57,40 @@ export default function Home() {
   );
 
   const handleUpload = async () => {
-    if (!file) return;
+    if (mode === 'file' && !file) return;
+    if (mode === 'text' && !text.trim()) return;
+
     try {
       setState('encrypting');
       const key = await generateKey();
       const keyString = await exportKey(key);
-      const encryptedBlob = await encryptFileStream(file, key);
+
+      let encryptedBlob: Blob;
+      let fileName: string;
+      let fileSize: number;
+
+      if (mode === 'file' && file) {
+        encryptedBlob = await encryptFileStream(file, key);
+        fileName = file.name;
+        fileSize = file.size;
+      } else {
+        // Text mode: create a blob from text and encrypt
+        const textBlob = new Blob([text], { type: 'text/plain' });
+        const textFile = new File([textBlob], 'note.txt', { type: 'text/plain' });
+        encryptedBlob = await encryptFileStream(textFile, key);
+        fileName = 'note.txt';
+        fileSize = textFile.size;
+      }
 
       setState('uploading');
 
-      // Step 1: Get presigned upload URL (small JSON request — no file data)
+      // Step 1: Get presigned upload URL
       const initRes = await fetch('/api/upload', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
-          file_name: file.name,
-          file_size: file.size,
+          file_name: fileName,
+          file_size: fileSize,
           expiry_hours: expiry.hours,
         }),
       });
@@ -79,7 +102,7 @@ export default function Home() {
 
       const { id: fileId, upload_url, token } = await initRes.json();
 
-      // Step 2: Upload encrypted blob directly to Supabase Storage (bypasses Vercel limit)
+      // Step 2: Upload encrypted blob directly to Supabase Storage
       const uploadRes = await fetch(upload_url, {
         method: 'PUT',
         headers: {
@@ -99,8 +122,8 @@ export default function Home() {
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
           id: fileId,
-          file_name: file.name,
-          file_size: file.size,
+          file_name: fileName,
+          file_size: fileSize,
           expiry_hours: expiry.hours,
         }),
       });
@@ -128,6 +151,7 @@ export default function Home() {
   const reset = () => {
     setState('idle');
     setFile(null);
+    setText('');
     setShareUrl('');
     setError('');
     setCopied(false);
@@ -142,6 +166,7 @@ export default function Home() {
     if (state === 'uploading') return 'TRANSMITTING: UPLOADING CIPHERTEXT // E2E ENCRYPTED...';
     if (state === 'done') return 'TRANSMISSION_COMPLETE: LINK ACTIVE';
     if (file) return `FILE_LOADED: ${file.name.toUpperCase()} — READY TO TRANSMIT`;
+    if (text) return `TEXT_LOADED: ${text.length} CHARS — READY TO TRANSMIT`;
     return 'SYSTEM_READY: WAITING FOR INPUT...';
   })();
 
@@ -184,127 +209,263 @@ export default function Home() {
 
         {state !== 'done' ? (
           <div className="flex flex-col items-center gap-6 w-full max-w-lg">
-            {/* The Event Horizon */}
-            <div
-              onDrop={handleDrop}
-              onDragOver={(e) => {
-                e.preventDefault();
-                setDragOver(true);
-              }}
-              onDragLeave={() => setDragOver(false)}
-              onClick={() => !isProcessing && fileInputRef.current?.click()}
-              className={`
-                w-56 h-56 sm:w-64 sm:h-64 rounded-full border-2
-                flex flex-col items-center justify-center
-                transition-all duration-100
-                ${isProcessing ? 'pointer-events-none' : 'cursor-pointer'}
-                ${dragOver ? 'event-horizon-dragover' : ''}
-                ${isProcessing ? 'event-horizon-active' : ''}
-                ${!dragOver && !isProcessing ? 'event-horizon' : ''}
-              `}
-            >
-              {/* Idle — no file */}
-              {!isProcessing && !file && (
-                <div className="flex flex-col items-center gap-3 text-center">
-                  <div className="text-[11px] text-muted tracking-[0.2em]">
-                    DROP FILE
+            {/* Mode Toggle */}
+            <div className="flex items-center gap-4 text-[11px] tracking-[0.15em]">
+              <button
+                onClick={() => {
+                  setMode('file');
+                  setText('');
+                  setError('');
+                }}
+                className={`px-4 py-1.5 border ${mode === 'file' ? 'ghost-btn-accent' : 'ghost-btn'}`}
+              >
+                FILE
+              </button>
+              <button
+                onClick={() => {
+                  setMode('text');
+                  setFile(null);
+                  setError('');
+                  if (fileInputRef.current) fileInputRef.current.value = '';
+                }}
+                className={`px-4 py-1.5 border ${mode === 'text' ? 'ghost-btn-accent' : 'ghost-btn'}`}
+              >
+                TEXT
+              </button>
+            </div>
+
+            {/* FILE Mode */}
+            {mode === 'file' && (
+              <>
+                {/* The Event Horizon */}
+                <div
+                  onDrop={handleDrop}
+                  onDragOver={(e) => {
+                    e.preventDefault();
+                    setDragOver(true);
+                  }}
+                  onDragLeave={() => setDragOver(false)}
+                  onClick={() => !isProcessing && fileInputRef.current?.click()}
+                  className={`
+                    w-56 h-56 sm:w-64 sm:h-64 rounded-full border-2
+                    flex flex-col items-center justify-center
+                    transition-all duration-100
+                    ${isProcessing ? 'pointer-events-none' : 'cursor-pointer'}
+                    ${dragOver ? 'event-horizon-dragover' : ''}
+                    ${isProcessing ? 'event-horizon-active' : ''}
+                    ${!dragOver && !isProcessing ? 'event-horizon' : ''}
+                  `}
+                >
+                  {/* Idle — no file */}
+                  {!isProcessing && !file && (
+                    <div className="flex flex-col items-center gap-3 text-center">
+                      <div className="text-[11px] text-muted tracking-[0.2em]">
+                        DROP FILE
+                      </div>
+                    </div>
+                  )}
+
+                  {/* Idle — file selected */}
+                  {!isProcessing && file && (
+                    <div className="flex flex-col items-center gap-2 text-center px-8">
+                      <FileIcon className="w-6 h-6 text-accent" />
+                      <p className="text-xs truncate max-w-[180px]">
+                        {file.name}
+                      </p>
+                      <p className="text-[11px] text-muted">
+                        {formatFileSize(file.size)}
+                      </p>
+                      <button
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          setFile(null);
+                          setError('');
+                          if (fileInputRef.current) fileInputRef.current.value = '';
+                        }}
+                        className="mt-1 text-muted hover:text-danger"
+                      >
+                        <X className="w-4 h-4" />
+                      </button>
+                    </div>
+                  )}
+
+                  {/* Processing */}
+                  {isProcessing && (
+                    <div className="flex flex-col items-center gap-4">
+                      <Loader2 className="w-6 h-6 text-accent animate-spin" />
+                      <div className="flex flex-col items-center gap-1.5">
+                        <ScrambleText
+                          key={state}
+                          text={state === 'encrypting' ? 'ENCRYPTING' : 'TRANSMITTING'}
+                          className="text-[11px] text-accent tracking-[0.15em]"
+                          scrambleDuration={800}
+                        />
+                        <ScrambleText
+                          key={`${state}-sub`}
+                          text={state === 'encrypting'
+                            ? 'AES-256-GCM // 256-BIT KEY'
+                            : 'UPLOADING CIPHERTEXT...'}
+                          className="text-[10px] text-muted tracking-[0.1em]"
+                          scrambleDuration={1000}
+                        />
+                      </div>
+                    </div>
+                  )}
+                </div>
+
+                {/* Expiry picker + Upload — shown when file selected */}
+                {file && !isProcessing && (
+                  <div className="flex flex-col items-center gap-5">
+                    <div className="flex items-center gap-3">
+                      <span className="text-[11px] text-muted tracking-[0.15em]">
+                        SELF-DESTRUCT IN:
+                      </span>
+                      {EXPIRY_OPTIONS.map((option) => (
+                        <button
+                          key={option.hours}
+                          onClick={() => setExpiry(option)}
+                          className={`
+                            px-3 py-1.5 text-[11px] tracking-[0.15em] border
+                            ${
+                              expiry.hours === option.hours
+                                ? 'ghost-btn-accent'
+                                : 'ghost-btn'
+                            }
+                          `}
+                        >
+                          {option.tag}
+                        </button>
+                      ))}
+                    </div>
+
+                    <button
+                      onClick={handleUpload}
+                      className="ghost-btn-accent px-8 py-3 text-[11px] tracking-[0.2em] border"
+                    >
+                      [ ENCRYPT & SHARE ]
+                    </button>
+                  </div>
+                )}
+
+                {/* Error */}
+                {error && (
+                  <button
+                    onClick={() => {
+                      setError('');
+                      setState('idle');
+                    }}
+                    className="text-[11px] text-danger tracking-[0.1em] hover:underline"
+                  >
+                    [ RETRY ]
+                  </button>
+                )}
+              </>
+            )}
+
+            {/* TEXT Mode */}
+            {mode === 'text' && (
+              <>
+                {/* Terminal-style textarea */}
+                <div className="w-full max-w-md">
+                  <div className="border border-border bg-[#0d1117] rounded-sm overflow-hidden">
+                    <div className="flex items-center gap-2 px-3 py-2 border-b border-border">
+                      <div className="w-2 h-2 rounded-full bg-red-500/80" />
+                      <div className="w-2 h-2 rounded-full bg-yellow-500/80" />
+                      <div className="w-2 h-2 rounded-full bg-green-500/80" />
+                      <span className="text-[10px] text-muted tracking-[0.1em] ml-2">TERMINAL</span>
+                    </div>
+                    <div className="relative">
+                      <span className="absolute top-3 left-3 text-[11px] text-accent pointer-events-none">$</span>
+                      <textarea
+                        ref={textareaRef}
+                        value={text}
+                        onChange={(e) => {
+                          if (e.target.value.length <= MAX_TEXT_SIZE) {
+                            setText(e.target.value);
+                          }
+                        }}
+                        placeholder="paste your text here..."
+                        disabled={isProcessing}
+                        className="w-full h-48 bg-transparent text-[11px] text-fg font-mono pl-7 pr-3 py-3 resize-none focus:outline-none placeholder:text-muted/50"
+                        spellCheck={false}
+                      />
+                    </div>
+                    <div className="px-3 py-2 border-t border-border flex items-center justify-between">
+                      <span className="text-[10px] text-muted">
+                        {text.length}/{MAX_TEXT_SIZE} chars
+                      </span>
+                      {text.length > 0 && (
+                        <button
+                          onClick={() => setText('')}
+                          className="text-[10px] text-muted hover:text-danger"
+                        >
+                          CLEAR
+                        </button>
+                      )}
+                    </div>
                   </div>
                 </div>
-              )}
 
-              {/* Idle — file selected */}
-              {!isProcessing && file && (
-                <div className="flex flex-col items-center gap-2 text-center px-8">
-                  <FileIcon className="w-6 h-6 text-accent" />
-                  <p className="text-xs truncate max-w-[180px]">
-                    {file.name}
-                  </p>
-                  <p className="text-[11px] text-muted">
-                    {formatFileSize(file.size)}
-                  </p>
-                  <button
-                    onClick={(e) => {
-                      e.stopPropagation();
-                      setFile(null);
-                      setError('');
-                      if (fileInputRef.current) fileInputRef.current.value = '';
-                    }}
-                    className="mt-1 text-muted hover:text-danger"
-                  >
-                    <X className="w-4 h-4" />
-                  </button>
-                </div>
-              )}
+                {/* Expiry picker + Upload */}
+                {text.trim() && !isProcessing && (
+                  <div className="flex flex-col items-center gap-5">
+                    <div className="flex items-center gap-3">
+                      <span className="text-[11px] text-muted tracking-[0.15em]">
+                        SELF-DESTRUCT IN:
+                      </span>
+                      {EXPIRY_OPTIONS.map((option) => (
+                        <button
+                          key={option.hours}
+                          onClick={() => setExpiry(option)}
+                          className={`
+                            px-3 py-1.5 text-[11px] tracking-[0.15em] border
+                            ${
+                              expiry.hours === option.hours
+                                ? 'ghost-btn-accent'
+                                : 'ghost-btn'
+                            }
+                          `}
+                        >
+                          {option.tag}
+                        </button>
+                      ))}
+                    </div>
 
-              {/* Processing */}
-              {isProcessing && (
-                <div className="flex flex-col items-center gap-4">
-                  <Loader2 className="w-6 h-6 text-accent animate-spin" />
-                  <div className="flex flex-col items-center gap-1.5">
+                    <button
+                      onClick={handleUpload}
+                      className="ghost-btn-accent px-8 py-3 text-[11px] tracking-[0.2em] border"
+                    >
+                      [ ENCRYPT & SHARE ]
+                    </button>
+                  </div>
+                )}
+
+                {/* Processing */}
+                {isProcessing && (
+                  <div className="flex flex-col items-center gap-2">
+                    <Loader2 className="w-5 h-5 text-accent animate-spin" />
                     <ScrambleText
                       key={state}
                       text={state === 'encrypting' ? 'ENCRYPTING' : 'TRANSMITTING'}
                       className="text-[11px] text-accent tracking-[0.15em]"
                       scrambleDuration={800}
                     />
-                    <ScrambleText
-                      key={`${state}-sub`}
-                      text={state === 'encrypting'
-                        ? 'AES-256-GCM // 256-BIT KEY'
-                        : 'UPLOADING CIPHERTEXT...'}
-                      className="text-[10px] text-muted tracking-[0.1em]"
-                      scrambleDuration={1000}
-                    />
                   </div>
-                </div>
-              )}
-            </div>
+                )}
 
-            {/* Expiry picker + Upload — shown when file selected */}
-            {file && !isProcessing && (
-              <div className="flex flex-col items-center gap-5">
-                <div className="flex items-center gap-3">
-                  <span className="text-[11px] text-muted tracking-[0.15em]">
-                    SELF-DESTRUCT IN:
-                  </span>
-                  {EXPIRY_OPTIONS.map((option) => (
-                    <button
-                      key={option.hours}
-                      onClick={() => setExpiry(option)}
-                      className={`
-                        px-3 py-1.5 text-[11px] tracking-[0.15em] border
-                        ${
-                          expiry.hours === option.hours
-                            ? 'ghost-btn-accent'
-                            : 'ghost-btn'
-                        }
-                      `}
-                    >
-                      {option.tag}
-                    </button>
-                  ))}
-                </div>
-
-                <button
-                  onClick={handleUpload}
-                  className="ghost-btn-accent px-8 py-3 text-[11px] tracking-[0.2em] border"
-                >
-                  [ ENCRYPT & SHARE ]
-                </button>
-              </div>
-            )}
-
-            {/* Error */}
-            {error && (
-              <button
-                onClick={() => {
-                  setError('');
-                  setState('idle');
-                }}
-                className="text-[11px] text-danger tracking-[0.1em] hover:underline"
-              >
-                [ RETRY ]
-              </button>
+                {/* Error */}
+                {error && (
+                  <button
+                    onClick={() => {
+                      setError('');
+                      setState('idle');
+                    }}
+                    className="text-[11px] text-danger tracking-[0.1em] hover:underline"
+                  >
+                    [ RETRY ]
+                  </button>
+                )}
+              </>
             )}
           </div>
         ) : (

--- a/src/app/releases/page.tsx
+++ b/src/app/releases/page.tsx
@@ -8,6 +8,22 @@ export const metadata: Metadata = {
 
 const releases = [
   {
+    version: '0.2.1',
+    date: '2026-04-04',
+    title: 'Secure Notes',
+    changes: [
+      'New: `phntm note` command for encrypted text sharing',
+      'New: Terminal-style text input on web (FILE/TEXT toggle)',
+      'New: Inline note rendering on web (read notes directly)',
+      'New: Copy button for notes in web UI',
+      'CLI: Notes render inline in terminal with formatted box',
+      'CLI: Pipe support for notes (`phntm get url | pbcopy`)',
+      'Limit: 10KB max for text notes',
+    ],
+    cli: true,
+    web: true,
+  },
+  {
     version: '0.2.0',
     date: '2026-04-01',
     title: 'Streaming Encryption',


### PR DESCRIPTION
## Summary

Adds secure text note sharing to the web UI. Users can paste text (credentials, passwords, snippets) and get an encrypted, self-destructing link — same as files but for text.

## Changes

### Homepage
- FILE/TEXT toggle tabs (terminal-style aesthetic)
- Terminal-style textarea for text input:
  - Monospace font (system font)
  - Dark theme (#0d1117 background)
  - Blinking cursor effect
  - $ prompt prefix
  - Character counter (10KB limit)
- Same encryption/upload flow as files
- Notes stored as `note.txt`
- **Updated hero:** "SEND IT. IT DISAPPEARS." with files/notes/credentials mention

### Download Page
- Detect `.txt` files and render inline
- Terminal-style note display
- Copy button (primary action)
- Download button (secondary action)

### Releases Page
- Added v0.2.1 release notes

## Screenshots

### Homepage - FILE Mode
Existing file upload experience unchanged.

### Homepage - TEXT Mode
Terminal-style textarea with $ prompt and character counter.

### Download Page - Note View
Inline rendering with copy/download buttons.

## Related

- CLI Issue: [phntm-cli #13](https://github.com/aliirz/phntm-cli/issues/13)
- Web Issue: [phntm.sh #41](https://github.com/aliirz/phntm.sh/issues/41)

## Testing

1. Homepage toggle between FILE and TEXT modes
2. Enter text and verify character limit
3. Submit note and get share link
4. Open link and verify inline rendering
5. Test copy and download buttons